### PR TITLE
Add distutils to remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,8 @@ Imports:
     ggpubr,
     infotheo,
     GenSA
+Remotes:
+    Albluca/distutils
 RoxygenNote: 6.0.1
 Suggests: knitr,
     rmarkdown


### PR DESCRIPTION
Add distutils to remotes so that ElPiGraph.R can be installed with one line without having to install distutils separately