### PR TITLE
changed plotPieNet -> add RootLevel argument

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -167,6 +167,7 @@ plotPieNet <- function(X,
                        LayOut = 'nicely',
                        LayoutIter = 500,
                        TreeRoot = numeric(),
+                       RootLevel = numeric(),
                        distMeth = "manhattan",
                        Main="",
                        ScaleFunction = sqrt,
@@ -261,7 +262,8 @@ plotPieNet <- function(X,
   LayOutDONE <- FALSE
   
   if(LayOut == 'tree'){
-    RestrNodes <- igraph::layout_as_tree(graph = igraph::as.undirected(Net, mode = 'collapse'), root = TreeRoot)
+    RestrNodes <- igraph::layout_as_tree(graph = igraph::as.undirected(Net, mode = 'collapse'), root = TreeRoot,
+                                         rootlevel = RootLevel);
     LayOutDONE <- TRUE
   }
   


### PR DESCRIPTION
Dear Luca,

I hope you are going well. I wanted to propose to you this very small PR. Free to you to take it or not :)

I have figured out that in the ```plotPieNet``` function, if one wants to set two Roots, ```LayOut = "tree", TreeRoot = c(root1, root2)```, then the function will consider that the two roots begin at the exact same level (or same pseudotime if you like) as illustrated below:

![no_levels](https://user-images.githubusercontent.com/23334620/40985396-4e547f42-68e4-11e8-96e3-ab65a472af04.png)

But you can actually change this behaviour in the ```igraph::layout_as_tree``` function if you permit it to set a ```rootlevel``` argument. For instance: setting the function to ```igraph::layout_as_tree(graph = igraph::as.undirected(Net, mode = 'collapse'), root = TreeRoot, rootlevel = c(6, 1))``` will eventually lead to this plot

![levels](https://user-images.githubusercontent.com/23334620/40985733-053f8f58-68e5-11e8-809a-eccc275a904b.png)

Perhaps could this small change be useful for users dealing with converging roots in their trajectories (i.e me ahah !)...

Anyway, I wish you a nice evening !

See you around ;)

Charles
